### PR TITLE
feat: write archives to home with new timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Optional flags:
 
 ## 📂 Output
 
-Outputs a **`.zip`** archive to `/tmp` by default:
+Outputs a **`.zip`** archive to your **home directory** by default:
 
 ```
-/tmp/diagnosticgpt-<host>-<timestamp>.zip
+~/diagnosticgpt-<timestamp>.zip
 ```
 
-Use `--archive-format tar` to produce `/tmp/diagnosticgpt-<host>-<timestamp>.tar.gz` instead. If `-o` is used, the archive and snapshot folder will be written there instead.
+Use `--archive-format tar` to produce `~/diagnosticgpt-<timestamp>.tar.gz` instead. If `-o` is used, the snapshot folder will be created there, but the archive still lands in your home directory.
 
 Contents include:
 
@@ -80,7 +80,7 @@ Contents include:
 1. Locate your output file:
 
 ```bash
-ls /tmp/diagnosticgpt-*.zip
+ls ~/diagnosticgpt-*.zip
 ```
 
 2. Upload the `.zip` file directly into your ChatGPT conversation.


### PR DESCRIPTION
## Summary
- default diagnostic bundles now save to the user's home directory
- use 12-hour timestamp format in archive names
- document new archive location and retrieval steps

## Testing
- `bash -n diagnosticgpt.sh`
- `./diagnosticgpt.sh -h`

------
https://chatgpt.com/codex/tasks/task_e_6898aa36c054832aa4a8d0055e0479f9